### PR TITLE
NATIVE_TAGS 添加 'page-meta'

### DIFF
--- a/src/platform/wx/wxml.js
+++ b/src/platform/wx/wxml.js
@@ -70,7 +70,8 @@ const NATIVE_TAGS = new Set([
   'include',
   'block',
   'slot',
-  'movable-area'
+  'movable-area',
+  'page-meta'
 ])
 
 module.exports.isNativeTag = function isNativeTag (tag) {


### PR DESCRIPTION
基础库 2.9.0 开始支持
https://developers.weixin.qq.com/miniprogram/dev/component/page-meta.html